### PR TITLE
ci: action for api redeploy

### DIFF
--- a/.github/workflows/redeploy-api.yaml
+++ b/.github/workflows/redeploy-api.yaml
@@ -1,0 +1,19 @@
+name: Redeploy API
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "build/**"
+  workflow_dispatch:
+
+jobs:
+  deploy-vercel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trigger API redeploy
+        run: |
+          curl -d '' ${{ secrets.VERCEL_API_REDEPLOY_HOOK }}
+        shell: bash


### PR DESCRIPTION
Note, that this action only triggers a redeploy of the epic branch. We need to adapt later if we are ready for prod