### PR TITLE
fix 0xb96b maxFillSize

### DIFF
--- a/configs/0xB96b74874126A787720a464EAb3FBD2F35a5D14e.json
+++ b/configs/0xB96b74874126A787720a464EAb3FBD2F35a5D14e.json
@@ -2,6 +2,6 @@
   "minExclusivityPeriod": 4,
   "minProfitThreshold": 0.00005,
   "balanceMultiplier": 0.25,
-  "maxFillSize": 10000,
+  "maxFillSize": 5000,
   "originChainIds": [1,10,324,8453,34443,42161,59144,81457]
 }


### PR DESCRIPTION
Was accidentally set to 10k instead of 5k.

# 📥 Relayer Configuration Added

This PR adds a new configuration file inside the `/configs` directory for the relayer.

## 👤 Operator Information

You may provide the following details before submitting your PR. Alternatively, you can reach out to the Across team via private channels.

- **Operator Name** (optional):
- **Description** (optional):
- **Contact Information** (optional):

## 🧪 Verification Checklist

- [x] I have added my configuration file in the `/configs` directory.
- [x] I have ensured no other files have been modified.
- [x] I have successfully run the validation script: `yarn validate-configs` (Optional - this check also runs as a job in CI)
