### PR TITLE
feat: add exclusive relayer config for 0x0Dc1E92F

### DIFF
--- a/configs/0x0Dc1E92Fbcc8413b1341F4C1B1C203c3b1A03d73.json
+++ b/configs/0x0Dc1E92Fbcc8413b1341F4C1B1C203c3b1A03d73.json
@@ -1,0 +1,7 @@
+{
+    "minExclusivityPeriod": 2,
+    "minProfitThreshold": 0.00005,
+    "balanceMultiplier": 0.95,
+    "maxFillSize": 2500,
+    "originChainIds": [1, 56, 8453, 42161]
+}


### PR DESCRIPTION
## New Exclusive Relayer

**Address:** `0x0Dc1E92Fbcc8413b1341F4C1B1C203c3b1A03d73`

### Config
```json
{
    "minExclusivityPeriod": 2,
    "minProfitThreshold": 0.00005,
    "balanceMultiplier": 0.95,
    "maxFillSize": 2500,
    "originChainIds": [1, 56, 8453, 42161]
}
```

### Track Record

- **Active since:** December 2025
- **Total fills:** 17,160+
- **Chains:** Ethereum, BSC, Base, Arbitrum
- **Tokens:** USDC, USDT

**30-day performance:**
| Chain | Fills | Win Rate |
|-------|-------|----------|
| Arbitrum | 1,613 | 80.9% |
| BSC | 922 | 57.8% |
| Base | 479 | 30.3% |
| Mainnet | 311 | 38.9% |

### Infrastructure

- Custom Go relayer with sub-millisecond hot-path cache (zero I/O in critical execution path)
- Flashblocks event detection on Base
- 10+ parallel submission endpoints per chain (sequencer direct, bloXroute, Alchemy, QuickNode, Infura)
- AWS us-east-1 deployment
- Step-in fills for expired exclusivity deposits
- 24/7 uptime with automatic reconnection and circuit breakers